### PR TITLE
Resolves #12: Properly handle blackjack tiebreaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+checksum = "1f35c303ea3e062b6131be4de16debe23860b9d3f2396658f13b7af1987fb473"
 dependencies = [
  "indexmap",
  "nom8",

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,4 +1,5 @@
 dealer_training_iterations = 10000000
+blackjack_payout_ratio = 1.2
 base_fee_fraction = 0.0
 dual_bust_protection = true
 print_dealer_table = true


### PR DESCRIPTION
The current implementation treats all dealer 21s as blackjacks. This is not correct, as a 21 with 3 or more cards is
beaten by a true blackjack.

Handle this by creating a separate `HandValue` enum to encapsulate regular hand values as well as blackjacks, and
define a separate entry in the dealer table for blackjacks (coming after the cell for 21).

The enum also defines an iterator method to return all better hand values, which is used instead of a standard range
in the sums over the dealer probability table.