### PR TITLE
Allow supplying static config variables via toml file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "serde_json",
  "signifix",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -73,6 +74,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +109,21 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-bigint"
@@ -260,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "signifix"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +350,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 signifix = "0.10.1"
 thiserror = "1.0.38"
+toml = "0.7.1"

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,3 +1,4 @@
 dealer_training_iterations = 10000000
 base_fee_fraction = 0.0
 dual_bust_protection = true
+print_dealer_table = true

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,0 +1,3 @@
+dealer_training_iterations = 10000000
+base_fee_fraction = 0.0
+dual_bust_protection = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,7 @@ struct Config {
     blackjack_payout_ratio: Option<f64>,
     base_fee_fraction: Option<f64>,
     dual_bust_protection: Option<bool>,
+    print_dealer_table: Option<bool>,
 }
 
 fn main_wrapper(config_file: Option<&str>) -> Option<()> {
@@ -600,22 +601,24 @@ fn main_wrapper(config_file: Option<&str>) -> Option<()> {
         },
     };
     model.simulate(dealer_training_iterations);
-    let probabilities = model.probabilities();
-    let relative_stderrs = model.relative_stderrs();
-    for i in 0..10 {
-        let counts: Vec<String> = izip!(probabilities[i].iter(), relative_stderrs[i].iter())
-            .enumerate()
-            .filter(|(_, (prob, _))| **prob > 0.0)
-            .map(|(idx, (prob, rel_stderr))| {
-                format!(
-                    "{}:{:.5}+-{:.5}",
-                    idx,
-                    *prob as f64,
-                    (*prob * (1.0 - *prob)).sqrt() * rel_stderr
-                )
-            })
-            .collect();
-        println!("{}: {:?}", i + 1, counts);
+    if config.print_dealer_table.unwrap_or(true) {
+        let probabilities = model.probabilities();
+        let relative_stderrs = model.relative_stderrs();
+        for i in 0..10 {
+            let counts: Vec<String> = izip!(probabilities[i].iter(), relative_stderrs[i].iter())
+                .enumerate()
+                .filter(|(_, (prob, _))| **prob > 0.0)
+                .map(|(idx, (prob, rel_stderr))| {
+                    format!(
+                        "{}:{:.5}+-{:.5}",
+                        idx,
+                        *prob as f64,
+                        (*prob * (1.0 - *prob)).sqrt() * rel_stderr
+                    )
+                })
+                .collect();
+            println!("{}: {:?}", i + 1, counts);
+        }
     }
     let mut optimizer = PlayerOptimizer::new(
         &model,


### PR DESCRIPTION
Allow all static parameters such as base fee ratio to be supplied to the program at runtime, either via entry via
standard input or via a config toml file supplied via the `--config` command line argument. This allows you to
change these values without recompiling the binary.

Also add a `config/default.toml` default configuration file.
